### PR TITLE
feat: support multiple other helm template flags

### DIFF
--- a/helm/internal/msg/Template.pkl.go
+++ b/helm/internal/msg/Template.pkl.go
@@ -1,6 +1,8 @@
 // Code generated from Pkl module `helm.helm`. DO NOT EDIT.
 package msg
 
+import "github.com/apple/pkl-readers/helm/internal/msg/hookpolicy"
+
 type Template interface {
 	Request
 
@@ -11,6 +13,14 @@ type Template interface {
 	GetReleaseName() string
 
 	GetNamespace() string
+
+	GetKubeVersion() *string
+
+	GetApiVersions() []string
+
+	GetSkipSchemaValidation() bool
+
+	GetHooks() hookpolicy.HookPolicy
 
 	GetValuesJson() string
 }
@@ -37,6 +47,18 @@ type TemplateImpl struct {
 
 	// Equivalent to the `--namespace` flag of `helm template`.
 	Namespace string `pkl:"namespace"`
+
+	// Equivalent to the `--kube-version` flag of `helm template`.
+	KubeVersion *string `pkl:"kubeVersion"`
+
+	// Equivalent to the `--api-versions` flag of `helm template`.
+	ApiVersions []string `pkl:"apiVersions"`
+
+	// Equivalent to the `--skip-schema-validation` flag of `helm template`.
+	SkipSchemaValidation bool `pkl:"skipSchemaValidation"`
+
+	// Equivalent to the `--no-hooks` and `--skip-tests` flags of `helm template`.
+	Hooks hookpolicy.HookPolicy `pkl:"hooks"`
 
 	ValuesJson string `pkl:"valuesJson"`
 }
@@ -68,6 +90,26 @@ func (rcv TemplateImpl) GetReleaseName() string {
 // Equivalent to the `--namespace` flag of `helm template`.
 func (rcv TemplateImpl) GetNamespace() string {
 	return rcv.Namespace
+}
+
+// Equivalent to the `--kube-version` flag of `helm template`.
+func (rcv TemplateImpl) GetKubeVersion() *string {
+	return rcv.KubeVersion
+}
+
+// Equivalent to the `--api-versions` flag of `helm template`.
+func (rcv TemplateImpl) GetApiVersions() []string {
+	return rcv.ApiVersions
+}
+
+// Equivalent to the `--skip-schema-validation` flag of `helm template`.
+func (rcv TemplateImpl) GetSkipSchemaValidation() bool {
+	return rcv.SkipSchemaValidation
+}
+
+// Equivalent to the `--no-hooks` and `--skip-tests` flags of `helm template`.
+func (rcv TemplateImpl) GetHooks() hookpolicy.HookPolicy {
+	return rcv.Hooks
 }
 
 func (rcv TemplateImpl) GetValuesJson() string {

--- a/helm/internal/msg/hookpolicy/HookPolicy.pkl.go
+++ b/helm/internal/msg/hookpolicy/HookPolicy.pkl.go
@@ -1,0 +1,37 @@
+// Code generated from Pkl module `helm.helm`. DO NOT EDIT.
+package hookpolicy
+
+import (
+	"encoding"
+	"fmt"
+)
+
+type HookPolicy string
+
+const (
+	Enabled   HookPolicy = "enabled"
+	SkipTests HookPolicy = "skip-tests"
+	Disabled  HookPolicy = "disabled"
+)
+
+// String returns the string representation of HookPolicy
+func (rcv HookPolicy) String() string {
+	return string(rcv)
+}
+
+var _ encoding.BinaryUnmarshaler = new(HookPolicy)
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler for HookPolicy.
+func (rcv *HookPolicy) UnmarshalBinary(data []byte) error {
+	switch str := string(data); str {
+	case "enabled":
+		*rcv = Enabled
+	case "skip-tests":
+		*rcv = SkipTests
+	case "disabled":
+		*rcv = Disabled
+	default:
+		return fmt.Errorf(`illegal: "%s" is not a valid HookPolicy`, str)
+	}
+	return nil
+}

--- a/helm/internal/template.go
+++ b/helm/internal/template.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,10 @@ import (
 	"strings"
 
 	"github.com/apple/pkl-readers/helm/internal/msg"
+	"github.com/apple/pkl-readers/helm/internal/msg/hookpolicy"
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart"
+	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	"helm.sh/helm/v4/pkg/downloader"
 	"helm.sh/helm/v4/pkg/getter"
@@ -53,8 +55,18 @@ func (r helmReader) template(req msg.Template) ([]byte, error) {
 	client.IncludeCRDs = true
 	client.ReleaseName = req.GetReleaseName()
 	client.Namespace = req.GetNamespace()
+	client.DisableHooks = req.GetHooks() == hookpolicy.Disabled
+	client.SkipSchemaValidation = req.GetSkipSchemaValidation()
+	client.APIVersions = req.GetApiVersions()
 	if version := req.GetVersion(); version != nil {
 		client.Version = *version
+	}
+	if kubeVersion := req.GetKubeVersion(); kubeVersion != nil {
+		parsedKubeVersion, err := common.ParseKubeVersion(*kubeVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid kube version '%s': %w", *kubeVersion, err)
+		}
+		client.KubeVersion = parsedKubeVersion
 	}
 
 	slog.Debug(
@@ -136,7 +148,7 @@ func (r helmReader) template(req msg.Template) ([]byte, error) {
 	_, _ = fmt.Fprintln(&manifests, strings.TrimSpace(rel.Manifest))
 	if !client.DisableHooks {
 		for _, m := range rel.Hooks {
-			if slices.Contains(m.Events, release.HookTest) {
+			if req.GetHooks() == hookpolicy.SkipTests && slices.Contains(m.Events, release.HookTest) {
 				continue
 			}
 			_, _ = fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, m.Manifest)

--- a/helm/pkl/helm.pkl
+++ b/helm/pkl/helm.pkl
@@ -31,6 +31,8 @@ hidden const readerName = "helm"
 
 local const packageVersion = read("VERSION.txt").text.trim()
 
+typealias HookPolicy = *"enabled" | "skip-tests" | "disabled"
+
 abstract class Request {
   fixed kind: String
 
@@ -68,6 +70,18 @@ class Template extends Request {
 
   /// Equivalent to the `--namespace` flag of `helm template`.
   namespace: String(!isEmpty)
+
+  /// Equivalent to the `--kube-version` flag of `helm template`.
+  kubeVersion: String?
+
+  /// Equivalent to the `--api-versions` flag of `helm template`.
+  apiVersions: Listing<String>
+
+  /// Equivalent to the `--skip-schema-validation` flag of `helm template`.
+  skipSchemaValidation: Boolean = false
+
+  /// Equivalent to the `--no-hooks` and `--skip-tests` flags of `helm template`.
+  hooks: HookPolicy
 
   /// The values to use during Helm chart templating.
   ///

--- a/helm/pkl/tests/fixtures/my-chart/Chart.yaml
+++ b/helm/pkl/tests/fixtures/my-chart/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,3 +36,4 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
+kubeVersion: "= 1.23.4"

--- a/helm/pkl/tests/template.pkl
+++ b/helm/pkl/tests/template.pkl
@@ -40,6 +40,7 @@ examples {
 
         releaseName = "my-release"
         namespace = "my-namespace"
+        kubeVersion = "1.23.4"
         values = new Dynamic {
           image {
             repository = "my-registry.example.com/nginx"

--- a/helm/pkl/tests/template.pkl-expected.pcf
+++ b/helm/pkl/tests/template.pkl-expected.pcf
@@ -75,7 +75,29 @@ examples {
         matchLabels:
           app.kubernetes.io/name: my-chart
           app.kubernetes.io/instance: my-release
-    
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+        helm.sh/hook: test
+      labels:
+        helm.sh/chart: my-chart-0.1.0
+        app.kubernetes.io/name: my-chart
+        app.kubernetes.io/instance: my-release
+        app.kubernetes.io/version: 1.16.0
+        app.kubernetes.io/managed-by: Helm
+      name: my-release-my-chart-test-connection
+    spec:
+      restartPolicy: Never
+      containers:
+      - image: busybox
+        command:
+        - wget
+        args:
+        - my-release-my-chart:80
+        name: wget
+
     """
   }
 }


### PR DESCRIPTION
Add support for:

-a, --api-versions strings    Kubernetes api versions used for
                              Capabilities.APIVersions (multiple can be
                              specified)
    --kube-version string     Kubernetes version used for
                              Capabilities.KubeVersion
    --no-hooks                prevent hooks from running during install
    --skip-schema-validation  if set, disables JSON schema validation
    --skip-tests              skip tests from templated output
    
Closes #18.